### PR TITLE
Add Continue to MCP Clients section

### DIFF
--- a/units/en/_toctree.yml
+++ b/units/en/_toctree.yml
@@ -38,6 +38,8 @@
     title: Building the Gradio MCP Server
   - local: unit2/clients
     title: Using MCP Clients with your application
+  - local: unit2/continue-client
+    title: Using MCP in the Your AI Coding Assitant
   - local: unit2/gradio-client
     title: Building an MCP Client with Gradio
   - local: unit2/tiny-agents


### PR DESCRIPTION
Hey @burtenshaw. I am starting with a small TOC update.

## The Plan

I've just joined Continue and in progress on updating our [MCP docs](https://docs.continue.dev/customize/deep-dives/mcp). I'd love to add some content to the course that assist in show how to use MCP servers in production. 

## Future Scope

Add more content on building coding related MCP servers using HuggingFace. 